### PR TITLE
Provide means to set Access-Control-Allow-Headers header

### DIFF
--- a/lib/sinatra/cross_origin.rb
+++ b/lib/sinatra/cross_origin.rb
@@ -32,10 +32,18 @@ module Sinatra
         origin = settings.allow_origin == :any ? request.env['HTTP_ORIGIN'] : settings.allow_origin
         methods = settings.allow_methods.map{ |m| m.to_s.upcase! }.join(', ')
 
-        headers 'Access-Control-Allow-Origin' => origin,
+        headers_list = {
+          'Access-Control-Allow-Origin' => origin,
           'Access-Control-Allow-Methods' => methods,
           'Access-Control-Allow-Credentials' => settings.allow_credentials.to_s,
-          'Access-Control-Max-Age' => settings.max_age.to_s 
+          'Access-Control-Max-Age' => settings.max_age.to_s
+        }
+
+        unless settings.allow_headers.empty?
+          headers_list['Access-Control-Allow-Headers'] = settings.allow_headers.join(', ')
+        end
+
+        headers headers_list
       end
     end
 
@@ -47,8 +55,8 @@ module Sinatra
       app.set :allow_origin, :any
       app.set :allow_methods, [:post, :get, :options]
       app.set :allow_credentials, true
+      app.set :allow_headers, []
       app.set :max_age, 1728000
-
 
       app.before do 
         cross_origin if settings.cross_origin

--- a/test/app/test_app.rb
+++ b/test/app/test_app.rb
@@ -31,6 +31,11 @@ class TestApp < Sinatra::Base
     "Allowing methods"
   end
 
+  get '/allow_headers' do
+    cross_origin :allow_headers => params[:allow_headers]
+    "Allowing headers"
+  end
+
   get '/dont_allow_credentials' do
     cross_origin :allow_credentials => false
     "Not allowing credentials"

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -14,6 +14,7 @@ class HelloTest < Test::Unit::TestCase
     assert_equal 'POST, GET, OPTIONS', last_response.headers['Access-Control-Allow-Methods']
     assert_equal 'true', last_response.headers['Access-Control-Allow-Credentials']
     assert_equal "1728000", last_response.headers['Access-Control-Max-Age']
+    assert_equal false, last_response.headers.has_key?('Access-Control-Allow-Headers')
   end
 
   def test_it_says_hello
@@ -44,6 +45,12 @@ class HelloTest < Test::Unit::TestCase
     get '/allow_methods', {:methods=>'get, post'}, {'HTTP_ORIGIN' => 'http://localhost'}
     assert last_response.ok?
     assert_equal 'GET, POST', last_response.headers['Access-Control-Allow-Methods']
+  end
+
+  def test_allow_headers
+    get '/allow_headers', {:allow_headers=>['Content-Type', 'Origin', 'Accept']}, {'HTTP_ORIGIN' => 'http://localhost'}
+    assert last_response.ok?
+    assert_equal 'Content-Type, Origin, Accept', last_response.headers['Access-Control-Allow-Headers']
   end
 
   def test_dont_allow_credentials


### PR DESCRIPTION
This was required in order to allow ember.js to talk to
my Sinatra API remotely (cross origin)
