### PR TITLE
Don't automatically register this extension

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,6 +23,12 @@ To only enable cross origin requests for certain routes:
       "This is available to cross-origin javascripts"
     end
 
+If you're using a modular application, remember to register this extension:
+
+``` ruby
+register Sinatra::CrossOrigin
+```
+
 ## Global Configuration
 
 You can set global options via the normal Sinatra set method:

--- a/lib/sinatra/cross_origin.rb
+++ b/lib/sinatra/cross_origin.rb
@@ -63,7 +63,4 @@ module Sinatra
 
     end
   end
-
-  register CrossOrigin
-
 end


### PR DESCRIPTION
Before this commit, this extension was automatically registered when this gem was `require`d. I don't think it's a good idea since everyone should clearly and explicitly register all the Sinatra extensions she's using.

I also updated the README to specify that.
