### PR TITLE
Add license to gemspec

### DIFF
--- a/sinatra-cross_origin.gemspec
+++ b/sinatra-cross_origin.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
     "test/test_helper.rb"
   ]
   s.homepage = "http://github.com/britg/sinatra-cross_origin"
+  s.license = "MIT"
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.25"
   s.summary = "Cross Origin Resource Sharing helper for Sinatra"


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.