### PR TITLE
[bugfix] register extension with sinatra

### DIFF
--- a/lib/sinatra/cross_origin.rb
+++ b/lib/sinatra/cross_origin.rb
@@ -79,4 +79,6 @@ module Sinatra
 
     end
   end
+
+  register CrossOrigin
 end


### PR DESCRIPTION
The extension was not registering itself with the framework and was not working as expected.
Using the configure block alone now will work for most of the required settings

```ruby
#config.ru

configure do
  enable :cross_origin
end
````
